### PR TITLE
Add footer to the page layout

### DIFF
--- a/resources/sass/_layout.scss
+++ b/resources/sass/_layout.scss
@@ -1,6 +1,14 @@
+// full height for footer
+html {
+    position: relative;
+    min-height: 100%;
+}
+
 // add some distance from the header
 body {
-  padding-top: 100px;
+    padding-top: 100px;
+    /* Margin bottom by footer height */
+    margin-bottom: 60px;
 }
 
 // override bootstraps max-height: 200px on small screens
@@ -17,6 +25,25 @@ body {
 // hide the username and password labels in the dropdown
 .login-form label {
     display: none;
+}
+
+// sticky footer
+.footer {
+    position: absolute;
+    bottom: 0;
+    width: 100%;
+    /* Set the fixed height of the footer here */
+    height: 60px;
+    background-color: $gray-lighter;
+}
+
+.footer p {
+    text-align: center;
+}
+
+.footer a {
+    margin: 20px 20px 0 20px;
+    display: inline-block;
 }
 
 // don't let the user resize textarea inputs

--- a/verleihtool/settings.py
+++ b/verleihtool/settings.py
@@ -67,6 +67,7 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
+                'verleihtool.templates.context_processors.template_settings',
             ],
             'libraries': {
                 'tags': 'verleihtool.templates.tags'
@@ -138,6 +139,11 @@ else:
 # Login
 
 LOGIN_REDIRECT_URL = '/'
+
+# Privacy and imprint
+PRIVACY_URL = '/'
+IMPRINT_URL = '/'
+GITHUB_URL = 'https://github.com/verleihtool/verleihtool/'
 
 # E-Mail preferences
 # Write Emails to std output instead of sending for development purposes

--- a/verleihtool/templates/context_processors.py
+++ b/verleihtool/templates/context_processors.py
@@ -1,0 +1,9 @@
+from django.conf import settings
+
+
+def template_settings(request):
+    return {
+        'PRIVACY_URL': settings.PRIVACY_URL,
+        'IMPRINT_URL': settings.IMPRINT_URL,
+        'GITHUB_URL': settings.GITHUB_URL,
+    }

--- a/verleihtool/templates/layout.html
+++ b/verleihtool/templates/layout.html
@@ -84,6 +84,16 @@
                     {% endblock %}
                 </div>
             {% endblock %}
+
+            <footer class="footer">
+                <div class="container">
+                    <p class="text-muted">
+                        <a href="{{ PRIVACY_URL }}">Privacy</a>
+                        <a href="{{ IMPRINT_URL }}">Imprint</a>
+                        <a href="{{ GITHUB_URL }}">Github</a>
+                    </p>
+                </div>
+            </footer>
         </div>
 
         <script src="{% static 'app.js' %}"></script>


### PR DESCRIPTION
The footer includes links to the privacy statement,
the imprint and the Github repository of this tool.
All urls can be configured via variables in settings.py.